### PR TITLE
handle TCP fragmentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ node_modules
 # Optional REPL history
 .node_repl_history
 lib
+.idea

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Hudson-Taylor TCP transport",
   "main": "lib/index.js",
   "scripts": {
-    "test": "semistandard && mocha -r babel-register -R spec --bail",
+    "lint": "semistandard | snazzy",
+    "check": "mocha -r babel-register -R spec --bail",
+    "test": "npm run lint && npm run check",
     "build": "babel src -d lib",
     "prepublish": "npm run build"
   },
@@ -29,7 +31,8 @@
     "babel-register": "^6.5.2",
     "mocha": "^2.4.5",
     "openport": "0.0.4",
-    "semistandard": "^7.0.5"
+    "semistandard": "^7.0.5",
+    "snazzy": "^6.0.0"
   },
   "dependencies": {}
 }

--- a/src/chunkDecoder.js
+++ b/src/chunkDecoder.js
@@ -7,17 +7,18 @@ const chunkDecoder = (onDecoded) => {
 
   return function onDataChunk (chunk) {
     let start = 0;
-
     while (chunk.indexOf(CONSTANTS.PACKET_END, start) !== -1 && start < chunk.length) {
-      const offset = chunk.indexOf(CONSTANTS.PACKET_END);
-
-      const packet = (start === 0 && left.length)
-        ? Buffer.concat([left, chunk.slice(start, start + offset)])
-        : chunk.slice(start, start + offset);
-
+      const offset = chunk.indexOf(CONSTANTS.PACKET_END, start);
+      let packet;
+      if (start === 0 && left.length) {
+        packet = Buffer.concat([left, chunk.slice(start, offset)]);
+        left = Buffer.alloc(0);
+      } else {
+        packet = chunk.slice(start, offset);
+      }
       const decoded = decode(packet);
       onDecoded(decoded);
-      start += offset + 1;
+      start = offset + 1;
     }
     if (start < chunk.length) {
       left = Buffer.concat([left, chunk.slice(start)]);

--- a/src/chunkDecoder.js
+++ b/src/chunkDecoder.js
@@ -1,0 +1,28 @@
+'use strict';
+
+import {decode, CONSTANTS} from './protocol';
+
+const chunkDecoder = (onDecoded) => {
+  let left = Buffer.alloc(0);
+
+  return function onDataChunk (chunk) {
+    let start = 0;
+
+    while (chunk.indexOf(CONSTANTS.PACKET_END, start) !== -1 && start < chunk.length) {
+      const offset = chunk.indexOf(CONSTANTS.PACKET_END);
+
+      const packet = (start === 0 && left.length)
+        ? Buffer.concat([left, chunk.slice(start, start + offset)])
+        : chunk.slice(start, start + offset);
+
+      const decoded = decode(packet);
+      onDecoded(decoded);
+      start += offset + 1;
+    }
+    if (start < chunk.length) {
+      left = Buffer.concat([left, chunk.slice(start)]);
+    }
+  };
+};
+
+export default chunkDecoder;

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -9,8 +9,7 @@ const PACKET_END = '\u0004';
 const HEADER_DELIMITER = '/';
 const FORMAT = {
   'JSON': 1,
-  'BINARY': 2,
-  'TEXT': 3
+  'TEXT': 2
 };
 
 export const CONSTANTS = {
@@ -23,9 +22,7 @@ export const CONSTANTS = {
 
 export const encode = ({method, data, id}, error) => {
   id = id || crypto.randomBytes(10).toString('hex');
-  const format = Buffer.isBuffer(data)
-    ? CONSTANTS.FORMAT.BINARY
-    : typeof data === 'string'
+  const format = typeof data === 'string'
       ? CONSTANTS.FORMAT.TEXT
       : CONSTANTS.FORMAT.JSON;
 
@@ -34,9 +31,6 @@ export const encode = ({method, data, id}, error) => {
   switch (format) {
     case FORMAT.JSON:
       dataBuf = Buffer.from(JSON.stringify(data));
-      break;
-    case FORMAT.BINARY:
-      dataBuf = data;
       break;
     case FORMAT.TEXT:
       dataBuf = Buffer.from(data);
@@ -65,16 +59,10 @@ export const decode = (packet) => {
   let [id, method, dataLength, format, errString] = packet.slice(headerIndex.start, headerIndex.end).toString().split(HEADER_DELIMITER);
   format = parseInt(format, 10);
   dataLength = parseInt(dataLength, 10);
-  // if (dataIndex.end - dataIndex.start !== dataLength) {
-  //   return null;
-  // }
   let data;
   switch (format) {
     case FORMAT.JSON:
       data = JSON.parse(packet.slice(dataIndex.start, dataIndex.end).toString());
-      break;
-    case FORMAT.BINARY:
-      data = packet.slice(dataIndex.start, dataIndex.end);
       break;
     case FORMAT.TEXT:
       data = packet.slice(dataIndex.start, dataIndex.end).toString();

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -1,0 +1,93 @@
+'use strict';
+
+import crypto from 'crypto';
+
+const HEADER_START = '\u0001';
+const DATA_START = '\u0002';
+const DATA_END = '\u0003';
+const PACKET_END = '\u0004';
+const HEADER_DELIMITER = '/';
+const FORMAT = {
+  'JSON': 1,
+  'BINARY': 2,
+  'TEXT': 3
+};
+
+export const CONSTANTS = {
+  HEADER_START,
+  DATA_START,
+  DATA_END,
+  PACKET_END,
+  FORMAT
+};
+
+export const encode = ({method, data, id}, error) => {
+  id = id || crypto.randomBytes(10).toString('hex');
+  const format = Buffer.isBuffer(data)
+    ? CONSTANTS.FORMAT.BINARY
+    : typeof data === 'string'
+      ? CONSTANTS.FORMAT.TEXT
+      : CONSTANTS.FORMAT.JSON;
+
+  let dataBuf;
+  const errString = error ? JSON.stringify(error) : '';
+  switch (format) {
+    case FORMAT.JSON:
+      dataBuf = Buffer.from(JSON.stringify(data));
+      break;
+    case FORMAT.BINARY:
+      dataBuf = data;
+      break;
+    case FORMAT.TEXT:
+      dataBuf = Buffer.from(data);
+      break;
+  }
+
+  return Buffer.concat([
+    Buffer.from(HEADER_START),
+    Buffer.from([id, method, dataBuf.length, format, errString].join(HEADER_DELIMITER)),
+    Buffer.from(DATA_START),
+    dataBuf,
+    Buffer.from(DATA_END),
+    Buffer.from(PACKET_END)
+  ]);
+};
+
+export const decode = (packet) => {
+  const headerIndex = {
+    start: packet.indexOf(HEADER_START) + HEADER_START.length,
+    end: packet.indexOf(DATA_START)
+  };
+  const dataIndex = {
+    start: packet.indexOf(DATA_START) + DATA_START.length,
+    end: packet.indexOf(Buffer.from(DATA_END + PACKET_END))
+  };
+  let [id, method, dataLength, format, errString] = packet.slice(headerIndex.start, headerIndex.end).toString().split(HEADER_DELIMITER);
+  format = parseInt(format, 10);
+  dataLength = parseInt(dataLength, 10);
+  // if (dataIndex.end - dataIndex.start !== dataLength) {
+  //   return null;
+  // }
+  let data;
+  switch (format) {
+    case FORMAT.JSON:
+      data = JSON.parse(packet.slice(dataIndex.start, dataIndex.end).toString());
+      break;
+    case FORMAT.BINARY:
+      data = packet.slice(dataIndex.start, dataIndex.end);
+      break;
+    case FORMAT.TEXT:
+      data = packet.slice(dataIndex.start, dataIndex.end).toString();
+      break;
+  }
+  const header = {
+    id, method, dataLength, format
+  };
+  if (errString) {
+    header.error = JSON.parse(errString);
+  }
+  return {
+    header,
+    data
+  };
+};

--- a/test/index.js
+++ b/test/index.js
@@ -153,12 +153,10 @@ describe('TCP Transport', function () {
         _data += `A${i}.`;
         _data2 += `B${i}.`;
       }
-      _data = Buffer.from(_data);
-      _data2 = Buffer.from(_data2);
 
       server = new transport.Server(function (method, data, callback) {
         assert.equal(method, _method);
-        assert.equal(Buffer.compare(data, _data), 0);
+        assert.equal(data, _data);
         callback(null, _data2);
       });
 
@@ -177,7 +175,7 @@ describe('TCP Transport', function () {
         clientSocket.on('data', chunkDecoder((response) => {
           clientSocket.end();
           assert.ifError(response.error);
-          assert.equal(Buffer.compare(response.data, _data2), 0);
+          assert.equal(response.data, _data2, 0);
           server.stop(done);
         }));
       });


### PR DESCRIPTION
This PR for handling TCP packet fragmentation. It defines simple protocol with header and data.
Format:
```
const HEADER_START = '\u0001';
const DATA_START = '\u0002';
const DATA_END = '\u0003';
const PACKET_END = '\u0004';
const HEADER_DELIMITER = '/';

Message:
<HEADER_START>
<id><HEADER_DELIMITER><method><HEADER_DELIMITER><data length><HEADER_DELIMITER><format><HEADER_DELIMITER><error>
<DATA_START>
<data_bytes>
<DATA_END>
<PACKET_END>
```

This protocol is needed to handle situations when TCP protocol divide long message into smaller parts to fit MTU.

@SomeoneWeird as for current version of tcp-transport, the new one covers 100% functionality + fragmentation handling. But if it's necessary we can modify protocol to handle true binary data (now it can handle only binary data that doesn't contain any protocol characters). If binary transport is needed, then protocol should be slightly different - with fixed-length header places for metadata. This will lead to maximum data size limit (because we'll have limited number of bytes for data length in header).

PS: Do not rush to merge this PR. Depending on decision on previous question the code could be simplified a bit or rewritten.